### PR TITLE
Add support for `log` amd `anyhow` 

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,7 @@
+[alias]
+
+test-formati = "test -- test_formati --test-threads=1"
+test-anyhow = "test --features tracing -- test_anyhow --test-threads=1"
+test-log = "test --no-default-features --features log -- test_log --test-threads=1"
+test-stdio = " test --no-default-features --features stdio -- test_stdio --nocapture --quiet --test-threads=1"
+test-tracing = "test --features tracing -- test_tracing --test-threads=1"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+.tmp
+.trash
+.vscode
 /target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,10 +16,13 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "formati"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
+ "anyhow",
+ "log",
  "proc-macro2",
  "quote",
+ "stdio-override",
  "syn",
  "tracing",
  "tracing-subscriber",
@@ -24,6 +33,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.172"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "log"
@@ -91,6 +106,16 @@ name = "smallvec"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+
+[[package]]
+name = "stdio-override"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffa8a2e517b4e9f270c47e1c4120df90506d9451c1efa67e3698d66446d30ce"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formati"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["nobane"]
 description = "Enhanced formatting macros with dotted notation and expression interpolation"
@@ -11,11 +11,21 @@ repository = "https://github.com/nobane/formati"
 [lib]
 proc-macro = true
 
+[features]
+default = []
+anyhow = []
+log = []
+stdio = []
+tracing = []
+
 [dependencies]
-syn   = { version = "2", features = ["full"] }
-quote = "1"
 proc-macro2 = "1.0.95"
+quote = "1"
+syn = { version = "2", features = ["full"] }
 
 [dev-dependencies]
+anyhow = "1.0.98"
+log = "0.4.27"
+stdio-override = "0.2"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"

--- a/src/formati_args.rs
+++ b/src/formati_args.rs
@@ -1,0 +1,184 @@
+use std::collections::HashMap;
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{quote, ToTokens as _};
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_macro_input,
+    punctuated::Punctuated,
+    Expr, ExprAssign, LitStr, Token,
+};
+
+/// input: `"literal"` [`,` expr ]*
+struct Input {
+    fmt_lit: LitStr,
+    rest: Punctuated<Expr, Token![,]>,
+}
+
+impl Parse for Input {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        // the format string literal is always required
+        let fmt_lit: LitStr = input.parse()?;
+
+        // no arguments at all
+        if input.is_empty() {
+            return Ok(Self {
+                fmt_lit,
+                rest: Punctuated::new(),
+            });
+        }
+
+        // if we **do** see a comma, decide whether it starts a real argument list
+        // or is just a trailing comma before the right-paren / end-of-macro.
+        if input.peek(Token![,]) {
+            let _: Token![,] = input.parse()?; // eat the comma
+
+            // ① nothing else → it's a lone trailing comma → zero extra args
+            if input.is_empty() {
+                return Ok(Self {
+                    fmt_lit,
+                    rest: Punctuated::new(),
+                });
+            }
+
+            // ② there *is* more input → parse the normal arg list (allows its
+            //    own trailing comma too).
+            let rest = Punctuated::<Expr, Token![,]>::parse_terminated(input)?;
+            return Ok(Self { fmt_lit, rest });
+        }
+
+        // anything else after the literal is a syntax error; let syn report it
+        Err(input.error("expected `,` or end of macro input"))
+    }
+}
+
+/// Process anyhow-like error macros with dotted notation support
+pub fn wrap(wrapped: TokenStream2, input: TokenStream) -> TokenStream {
+    let Input { fmt_lit, rest } = parse_macro_input!(input as Input);
+
+    let (out_lit, dot_args) = formati_args(&fmt_lit);
+
+    let (named, positional) = categorize(rest);
+
+    let lit = LitStr::new(&out_lit, fmt_lit.span());
+
+    TokenStream::from(quote! {
+        ::#wrapped!(
+            #lit
+            #(, #named)*
+            #(, #dot_args)*
+            #(, #positional)*
+        )
+    })
+}
+
+/// Split arguments into named and positional
+fn categorize(args: Punctuated<Expr, Token![,]>) -> (Vec<TokenStream2>, Vec<TokenStream2>) {
+    let mut named = Vec::new();
+    let mut positional = Vec::new();
+    for expr in args {
+        match expr {
+            x @ Expr::Assign(ExprAssign { .. }) => named.push(x.to_token_stream()),
+            x => positional.push(x.to_token_stream()),
+        }
+    }
+    (named, positional)
+}
+
+/// Process a format string, handling dotted/tuple notations
+pub fn formati_args(fmt_lit: &LitStr) -> (String, Vec<proc_macro2::TokenStream>) {
+    let src = fmt_lit.value();
+    let mut out_lit = String::with_capacity(src.len());
+    let mut dot_args = Vec::<proc_macro2::TokenStream>::new();
+    let mut expr_map: HashMap<String, usize> = HashMap::new(); // expression → index
+
+    let bytes = src.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        match bytes[i] {
+            // escaped '{{'
+            b'{' if bytes.get(i + 1) == Some(&b'{') => {
+                out_lit.push_str("{{");
+                i += 2;
+            }
+            // escaped '}}'
+            b'}' if bytes.get(i + 1) == Some(&b'}') => {
+                out_lit.push_str("}}");
+                i += 2;
+            }
+            // start of a real placeholder
+            b'{' => {
+                let start_inner = i + 1;
+                let mut j = start_inner;
+                let mut depth = 1;
+                while j < bytes.len() && depth != 0 {
+                    match bytes[j] {
+                        b'{' => depth += 1,
+                        b'}' => depth -= 1,
+                        _ => {}
+                    }
+                    j += 1;
+                }
+                assert!(depth == 0, "format!: unmatched `{{`");
+
+                // j is now *one past* the matching `}`
+                let piece = &src[start_inner..j - 1]; // inside braces
+                i = j; // continue after `}`
+
+                let (head, spec) = split_head_spec(piece);
+                if head.contains('.') {
+                    // dotted/tuple placeholder: de‑duplicate identical expressions
+                    let expr: Expr = syn::parse_str(head).expect("format!: invalid expression");
+                    let key = head.to_string();
+
+                    let idx = match expr_map.get(&key) {
+                        Some(&idx) => idx,
+                        None => {
+                            let idx = dot_args.len();
+                            expr_map.insert(key, idx);
+                            dot_args.push(expr.to_token_stream());
+                            idx
+                        }
+                    };
+
+                    // replace with indexed `{idx[:spec]}` placeholder
+                    out_lit.push('{');
+                    out_lit.push_str(&idx.to_string());
+                    if !spec.is_empty() {
+                        out_lit.push(':');
+                        out_lit.push_str(spec);
+                    }
+                    out_lit.push('}');
+                } else {
+                    // keep original placeholder verbatim
+                    out_lit.push('{');
+                    out_lit.push_str(piece);
+                    out_lit.push('}');
+                }
+            }
+            // ordinary character
+            ch => {
+                out_lit.push(ch as char);
+                i += 1;
+            }
+        }
+    }
+
+    (out_lit, dot_args)
+}
+
+// split `HEAD[:SPEC]`, ignoring `::` (path separators)
+fn split_head_spec(s: &str) -> (&str, &str) {
+    let mut chars = s.char_indices();
+    while let Some((idx, c)) = chars.next() {
+        if c == ':' {
+            // not part of '::'
+            if !matches!(chars.next(), Some((_, ':'))) {
+                return (&s[..idx], &s[idx + 1..]);
+            }
+        }
+    }
+    (s, "")
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,10 @@
-//! `formati!` – identical to `format!`, plus dotted / tuple‑index placeholders
-//! and automatic de‑duplication of repeated expressions.
-
 use proc_macro::TokenStream;
-use proc_macro2::{Spacing, TokenStream as Ts, TokenTree};
-use quote::{quote, ToTokens};
-use std::collections::HashMap;
-use syn::{
-    parse::{Parse, ParseStream},
-    parse2, parse_macro_input,
-    punctuated::Punctuated,
-    Expr, ExprAssign, ExprLit, Lit, LitStr, Token,
-};
+use proc_macro2::Span;
 
-/// # formati
+mod formati_args;
+use formati_args::wrap;
+
+/// # format
 ///
 /// Format strings with enhanced dotted notation and expression deduplication.
 ///
@@ -23,7 +15,7 @@ use syn::{
 /// ## Example
 ///
 /// ```
-/// use formati::formati;
+/// use formati::format;
 ///
 /// struct Point {
 ///     x: f32,
@@ -40,7 +32,7 @@ use syn::{
 ///
 /// // Multiple uses of point.x, point.y, and point.distance_from_origin()
 /// // will only be evaluated once each
-/// let formatted = formati!(
+/// let formatted = format!(
 ///     "Point: ({point.x}, {point.y})\n\
 ///      Distance: {point.distance_from_origin()}\n\
 ///      Normalized: ({point.x}/{point.distance_from_origin()}, {point.y}/{point.distance_from_origin()})"
@@ -52,10 +44,10 @@ use syn::{
 /// All standard format specifiers are supported, just like in `format!`:
 ///
 /// ```
-/// use formati::formati;
+/// use formati::format;
 ///
 /// let point = (3.14159, 2.71828);
-/// let formatted = formati!("Coordinates: ({point.0:.2}, {point.1:.3})");
+/// let formatted = format!("Coordinates: ({point.0:.2}, {point.1:.3})");
 /// assert_eq!(formatted, "Coordinates: (3.14, 2.718)");
 /// ```
 ///
@@ -65,295 +57,289 @@ use syn::{
 /// deduplicating them, and transforming the format string to use standard formatting syntax.
 /// This avoids evaluating repeated expressions multiple times at runtime.
 #[proc_macro]
-pub fn formati(input: TokenStream) -> TokenStream {
-    let Input { fmt_lit, rest } = parse_macro_input!(input as Input);
-
-    // Process the format string
-    let (out_lit, dot_args) = process_format_string(&fmt_lit);
-
-    let (named, positional) = categorize_arguments(rest);
-
-    let lit = LitStr::new(&out_lit, fmt_lit.span());
-
-    TokenStream::from(quote! {
-        ::std::format!(
-            #lit
-            #(, #named)*
-            #(, #dot_args)*
-            #(, #positional)*
-        )
-    })
-}
-
-/// `infox!( target: "my_app", user.id, ?error, "Hello {user.name}" )`
-#[proc_macro]
-pub fn info(input: TokenStream) -> TokenStream {
-    tracing_like("info", input)
-}
-
-/// `debugx!(a.b, "state = {a.b:?}")`
-#[proc_macro]
-pub fn debug(input: TokenStream) -> TokenStream {
-    tracing_like("debug", input)
+pub fn format(input: TokenStream) -> TokenStream {
+    let wrapped = syn::parse_quote_spanned!(Span::call_site() => std::format);
+    wrap(wrapped, input)
 }
 
 #[proc_macro]
+#[cfg(feature = "stdio")]
+pub fn print(input: TokenStream) -> TokenStream {
+    let wrapped = syn::parse_quote_spanned!(Span::call_site() => std::print);
+    wrap(wrapped, input)
+}
+
+#[proc_macro]
+#[cfg(feature = "stdio")]
+pub fn println(input: TokenStream) -> TokenStream {
+    let wrapped = syn::parse_quote_spanned!(Span::call_site() => std::println);
+    wrap(wrapped, input)
+}
+
+#[proc_macro]
+#[cfg(feature = "stdio")]
+pub fn eprint(input: TokenStream) -> TokenStream {
+    let wrapped = syn::parse_quote_spanned!(Span::call_site() => std::eprint);
+    wrap(wrapped, input)
+}
+
+#[proc_macro]
+#[cfg(feature = "stdio")]
+pub fn eprintln(input: TokenStream) -> TokenStream {
+    let wrapped = syn::parse_quote_spanned!(Span::call_site() => std::eprintln);
+    wrap(wrapped, input)
+}
+
+#[proc_macro]
+#[cfg(feature = "stdio")]
+pub fn dbg(input: TokenStream) -> TokenStream {
+    let wrapped = syn::parse_quote_spanned!(Span::call_site() => std::dbg);
+    wrap(wrapped, input)
+}
+
+#[proc_macro]
+#[cfg(feature = "stdio")]
+pub fn panic(input: TokenStream) -> TokenStream {
+    let wrapped = syn::parse_quote_spanned!(Span::call_site() => std::panic);
+    wrap(wrapped, input)
+}
+
+/// Enhanced version of anyhow! with dotted notation support
+///
+/// This macro wraps the standard anyhow! macro with support for
+/// dotted notation access to struct fields and automatic expression deduplication.
+///
+/// # Example
+///
+/// ```
+/// use formati::anyhow;
+///
+/// struct User {
+///     id: u32,
+///     name: String,
+/// }
+///
+/// let user = User {
+///    id: 42,
+///    name: String::from("Alice"),
+/// };
+///
+/// let err = anyhow!("Failed to process user {user.name} with ID {user.id}");
+/// ```
+#[proc_macro]
+#[cfg(feature = "anyhow")]
+pub fn anyhow(input: TokenStream) -> TokenStream {
+    let wrapped = syn::parse_quote_spanned!(Span::call_site() => anyhow::anyhow);
+    wrap(wrapped, input)
+}
+
+/// Enhanced version of bail! with dotted notation support
+///
+/// This macro wraps the standard bail! macro with support for
+/// dotted notation access to struct fields and automatic expression deduplication.
+///
+/// # Example
+///
+/// ```
+/// use formati::bail;
+/// use anyhow::Result;
+///
+/// struct User {
+///     id: u32,
+///     name: String,
+/// }
+///
+/// fn process_user(user: &User) -> Result<()> {
+///     if user.id == 0 {
+///         bail!("Invalid user {user.name} with ID {user.id}");
+///     }
+///     Ok(())
+/// }
+/// ```
+#[proc_macro]
+#[cfg(feature = "anyhow")]
+pub fn bail(input: TokenStream) -> TokenStream {
+    let wrapped = syn::parse_quote_spanned!(Span::call_site() => anyhow::bail);
+    wrap(wrapped, input)
+}
+
+#[cfg(feature = "tracing")]
+mod like_tracing;
+
+/// Enhanced version of trace! with dotted notation support
+///
+/// This macro wraps the standard trace! macro with support for
+/// dotted notation access to struct fields and automatic expression deduplication.
+///
+/// # Example
+///
+/// ```
+/// use formati::trace;
+///
+/// struct User {
+///     id: u32,
+///     name: String,
+/// }
+///
+/// let user = User {
+///    id: 42,
+///    name: String::from("Alice"),
+/// };
+///
+/// trace!("Trace: entering function with user={user.name}, id={user.id}");
+/// ```
+#[proc_macro]
+#[cfg(any(feature = "log", feature = "tracing"))]
 pub fn trace(input: TokenStream) -> TokenStream {
-    tracing_like("trace", input)
+    #[cfg(feature = "log")]
+    {
+        let wrapped = syn::parse_quote_spanned!(Span::call_site() => log::trace);
+        wrap(wrapped, input)
+    }
+    #[cfg(feature = "tracing")]
+    {
+        like_tracing::wrap("trace", input)
+    }
+}
+/// Enhanced version of debug! with dotted notation support
+///
+/// This macro wraps the standard debug! macro with support for
+/// dotted notation access to struct fields and automatic expression deduplication.
+///
+/// # Example
+///
+/// ```
+/// use formati::debug;
+///
+/// struct User {
+///     id: u32,
+///     name: String,
+/// }
+///
+/// let user = User {
+///    id: 42,
+///    name: String::from("Alice"),
+/// };
+///
+/// debug!("Debug: user object state: name={user.name}, id={user.id}");
+/// ```
+#[proc_macro]
+#[cfg(any(feature = "log", feature = "tracing"))]
+pub fn debug(input: TokenStream) -> TokenStream {
+    #[cfg(feature = "log")]
+    {
+        let wrapped = syn::parse_quote_spanned!(Span::call_site() => log::debug);
+        wrap(wrapped, input)
+    }
+    #[cfg(feature = "tracing")]
+    {
+        like_tracing::wrap("debug", input)
+    }
 }
 
+/// Enhanced version of info! with dotted notation support
+///
+/// This macro wraps the standard info! macro with support for
+/// dotted notation access to struct fields and automatic expression deduplication.
+///
+/// # Example
+///
+/// ```
+/// use formati::info;
+///
+/// struct User {
+///     id: u32,
+///     name: String,
+/// }
+///
+/// let user = User {
+///    id: 42,
+///    name: String::from("Alice"),
+/// };
+///
+/// info!("Processing user {user.name} with ID {user.id}");
+/// ```
 #[proc_macro]
+#[cfg(any(feature = "log", feature = "tracing"))]
+pub fn info(input: TokenStream) -> TokenStream {
+    #[cfg(feature = "log")]
+    {
+        let wrapped = syn::parse_quote_spanned!(Span::call_site() => log::info);
+        wrap(wrapped, input)
+    }
+    #[cfg(feature = "tracing")]
+    {
+        like_tracing::wrap("info", input)
+    }
+}
+/// Enhanced version of warn! with dotted notation support
+///
+/// This macro wraps the standard warn! macro with support for
+/// dotted notation access to struct fields and automatic expression deduplication.
+///
+/// # Example
+///
+/// ```
+/// use formati::warn;
+///
+/// struct User {
+///     id: u32,
+///     name: String,
+/// }
+///
+/// let user = User {
+///    id: 42,
+///    name: String::from("Alice"),
+/// };
+///
+/// warn!("warn: user {user.name} has suspicious activity");
+/// ```
+#[proc_macro]
+#[cfg(any(feature = "log", feature = "tracing"))]
+pub fn warn(input: TokenStream) -> TokenStream {
+    #[cfg(feature = "log")]
+    {
+        let wrapped = syn::parse_quote_spanned!(Span::call_site() => log::warn);
+        wrap(wrapped, input)
+    }
+    #[cfg(feature = "tracing")]
+    {
+        like_tracing::wrap("warn", input)
+    }
+}
+
+/// Enhanced version of error! with dotted notation support
+///
+/// This macro wraps the standard error! macro with support for
+/// dotted notation access to struct fields and automatic expression deduplication.
+///
+/// # Example
+///
+/// ```
+/// use formati::error;
+///
+/// struct User {
+///     id: u32,
+///     name: String,
+/// }
+///
+/// let user = User {
+///    id: 42,
+///    name: String::from("Alice"),
+/// };
+///
+/// error!("Failed to process user {user.name} with ID {user.id}");
+/// ```
+#[proc_macro]
+#[cfg(any(feature = "log", feature = "tracing"))]
 pub fn error(input: TokenStream) -> TokenStream {
-    tracing_like("error", input)
-}
-
-/// Wrapper for print! macro with dotted/tuple notation
-#[proc_macro]
-pub fn printi(input: TokenStream) -> TokenStream {
-    std_io_like("print", input)
-}
-
-/// Wrapper for println! macro with dotted/tuple notation
-#[proc_macro]
-pub fn printlni(input: TokenStream) -> TokenStream {
-    std_io_like("println", input)
-}
-
-/// Process a format string, handling dotted/tuple notations
-fn process_format_string(fmt_lit: &LitStr) -> (String, Vec<proc_macro2::TokenStream>) {
-    let src = fmt_lit.value();
-    let mut out_lit = String::with_capacity(src.len());
-    let mut dot_args = Vec::<proc_macro2::TokenStream>::new();
-    let mut expr_map: HashMap<String, usize> = HashMap::new(); // expression → index
-
-    let bytes = src.as_bytes();
-    let mut i = 0;
-
-    while i < bytes.len() {
-        match bytes[i] {
-            // escaped '{{'
-            b'{' if bytes.get(i + 1) == Some(&b'{') => {
-                out_lit.push_str("{{");
-                i += 2;
-            }
-            // escaped '}}'
-            b'}' if bytes.get(i + 1) == Some(&b'}') => {
-                out_lit.push_str("}}");
-                i += 2;
-            }
-            // start of a real placeholder
-            b'{' => {
-                let start_inner = i + 1;
-                let mut j = start_inner;
-                let mut depth = 1;
-                while j < bytes.len() && depth != 0 {
-                    match bytes[j] {
-                        b'{' => depth += 1,
-                        b'}' => depth -= 1,
-                        _ => {}
-                    }
-                    j += 1;
-                }
-                assert!(depth == 0, "formati!: unmatched `{{`");
-
-                // j is now *one past* the matching `}`
-                let piece = &src[start_inner..j - 1]; // inside braces
-                i = j; // continue after `}`
-
-                let (head, spec) = split_head_spec(piece);
-                if head.contains('.') {
-                    // dotted/tuple placeholder: de‑duplicate identical expressions
-                    let expr: Expr = syn::parse_str(head).expect("formati!: invalid expression");
-                    let key = head.to_string();
-
-                    let idx = match expr_map.get(&key) {
-                        Some(&idx) => idx,
-                        None => {
-                            let idx = dot_args.len();
-                            expr_map.insert(key, idx);
-                            dot_args.push(expr.to_token_stream());
-                            idx
-                        }
-                    };
-
-                    // replace with indexed `{idx[:spec]}` placeholder
-                    out_lit.push('{');
-                    out_lit.push_str(&idx.to_string());
-                    if !spec.is_empty() {
-                        out_lit.push(':');
-                        out_lit.push_str(spec);
-                    }
-                    out_lit.push('}');
-                } else {
-                    // keep original placeholder verbatim
-                    out_lit.push('{');
-                    out_lit.push_str(piece);
-                    out_lit.push('}');
-                }
-            }
-            // ordinary character
-            ch => {
-                out_lit.push(ch as char);
-                i += 1;
-            }
-        }
+    #[cfg(feature = "log")]
+    {
+        let wrapped = syn::parse_quote_spanned!(Span::call_site() => log::error);
+        wrap(wrapped, input)
     }
-
-    (out_lit, dot_args)
-}
-
-/// Split arguments into named and positional
-fn categorize_arguments(args: Punctuated<Expr, Token![,]>) -> (Vec<Ts>, Vec<Ts>) {
-    let mut named = Vec::new();
-    let mut positional = Vec::new();
-    for expr in args {
-        match expr {
-            x @ Expr::Assign(ExprAssign { .. }) => named.push(x.to_token_stream()),
-            x => positional.push(x.to_token_stream()),
-        }
-    }
-    (named, positional)
-}
-
-// split `HEAD[:SPEC]`, ignoring `::` (path separators)
-fn split_head_spec(s: &str) -> (&str, &str) {
-    let mut chars = s.char_indices();
-    while let Some((idx, c)) = chars.next() {
-        if c == ':' {
-            // not part of '::'
-            if !matches!(chars.next(), Some((_, ':'))) {
-                return (&s[..idx], &s[idx + 1..]);
-            }
-        }
-    }
-    (s, "")
-}
-
-/// Split on *top-level* commas — nothing else
-fn split_top_level(stream: Ts) -> Vec<Ts> {
-    let mut segs = Vec::<Ts>::new();
-    let mut cur = Ts::new();
-    for tt in stream {
-        match &tt {
-            TokenTree::Punct(p) if p.as_char() == ',' && p.spacing() == Spacing::Alone => {
-                segs.push(cur);
-                cur = Ts::new();
-            }
-            _ => cur.extend(std::iter::once(tt)),
-        }
-    }
-    segs.push(cur);
-    segs
-}
-
-/// Find format string and process tracing-like macros
-fn tracing_like(kind: &str, input: TokenStream) -> TokenStream {
-    let segments = split_top_level(Ts::from(input));
-
-    // ─── find the *last* string-literal segment — that starts the template –──
-    let split_at = segments
-        .iter()
-        .rposition(|seg| {
-            parse2::<Expr>(seg.clone())
-                .ok()
-                .and_then(|e| {
-                    if let Expr::Lit(ExprLit {
-                        lit: Lit::Str(_), ..
-                    }) = e
-                    {
-                        Some(())
-                    } else {
-                        None
-                    }
-                })
-                .is_some()
-        })
-        .expect("`*x!` macro needs a string literal message");
-
-    let (front_segs, back_segs) = segments.split_at(split_at);
-    let fmt_seg = &back_segs[0]; // the literal
-    let rest_segs = &back_segs[1..]; // possible extra exprs
-
-    // ─── pull out the literal text & span —──────────────────────────────────
-    let lit_expr: Expr = parse2(fmt_seg.clone()).unwrap();
-    let lit_str: LitStr = match lit_expr {
-        Expr::Lit(ExprLit {
-            lit: Lit::Str(s), ..
-        }) => s,
-        _ => unreachable!(),
-    };
-
-    // Process the format string to handle dotted/tuple notation
-    let (out, dot_args) = process_format_string(&lit_str);
-    let lit = LitStr::new(&out, lit_str.span());
-
-    // ─── extra args (after the literal): named first, then positional –──────
-    let mut named = Vec::<Ts>::new();
-    let mut positional = Vec::<Ts>::new();
-    for seg in rest_segs {
-        let expr: Expr = parse2(seg.clone()).expect("invalid expression after template");
-        match expr {
-            Expr::Assign(ExprAssign { .. }) => named.push(expr.to_token_stream()),
-            _ => positional.push(expr.to_token_stream()),
-        }
-    }
-
-    // ─── emit the real tracing macro call –──────────────────────────────────
-    let tracing_macro = syn::Ident::new(kind, proc_macro2::Span::call_site());
-    let front: Vec<&Ts> = front_segs.iter().collect();
-
-    quote! {
-        ::tracing::#tracing_macro!(
-            #(#front ,)*
-            #lit
-            #(, #named)*
-            #(, #dot_args)*
-            #(, #positional)*
-        )
-    }
-    .into()
-}
-
-/// Process std I/O macros like print! and println!
-fn std_io_like(kind: &str, input: TokenStream) -> TokenStream {
-    // Parse the input similarly to formati
-    let Input { fmt_lit, rest } = parse_macro_input!(input as Input);
-
-    // Process the format string
-    let (out_lit, dot_args) = process_format_string(&fmt_lit);
-
-    // Categorize arguments
-    let (named, positional) = categorize_arguments(rest);
-
-    // Create the final output
-    let lit = LitStr::new(&out_lit, fmt_lit.span());
-    let io_macro = syn::Ident::new(kind, proc_macro2::Span::call_site());
-
-    TokenStream::from(quote! {
-        ::std::#io_macro!(
-            #lit
-            #(, #named)*
-            #(, #dot_args)*
-            #(, #positional)*
-        )
-    })
-}
-
-/// input: `"literal"` [`,` expr ]*
-struct Input {
-    fmt_lit: LitStr,
-    rest: Punctuated<Expr, Token![,]>,
-}
-
-impl Parse for Input {
-    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
-        let fmt_lit: LitStr = input.parse()?;
-        let rest = if input.peek(Token![,]) {
-            let _: Token![,] = input.parse()?;
-            Punctuated::parse_terminated(input)?
-        } else {
-            Punctuated::new()
-        };
-        Ok(Self { fmt_lit, rest })
+    #[cfg(feature = "tracing")]
+    {
+        like_tracing::wrap("error", input)
     }
 }

--- a/src/like_tracing.rs
+++ b/src/like_tracing.rs
@@ -1,0 +1,90 @@
+use proc_macro::TokenStream;
+use proc_macro2::{Spacing, TokenStream as TokenStream2, TokenTree};
+use quote::{quote, ToTokens};
+use syn::{parse2, Expr, ExprAssign, ExprLit, Lit, LitStr};
+
+use crate::formati_args::formati_args;
+
+/// Split on *top-level* commas — nothing else
+fn split_top_level(stream: TokenStream2) -> Vec<TokenStream2> {
+    let mut segs = Vec::<TokenStream2>::new();
+    let mut cur = TokenStream2::new();
+    for tt in stream {
+        match &tt {
+            TokenTree::Punct(p) if p.as_char() == ',' && p.spacing() == Spacing::Alone => {
+                segs.push(cur);
+                cur = TokenStream2::new();
+            }
+            _ => cur.extend(std::iter::once(tt)),
+        }
+    }
+    segs.push(cur);
+    segs
+}
+
+/// Find format string and process tracing-like macros
+pub fn wrap(kind: &str, input: proc_macro::TokenStream) -> TokenStream {
+    let segments = split_top_level(TokenStream2::from(input));
+
+    // find the *last* string-literal segment — that starts the template
+    let split_at = segments
+        .iter()
+        .rposition(|seg| {
+            parse2::<Expr>(seg.clone())
+                .ok()
+                .and_then(|e| {
+                    if let Expr::Lit(ExprLit {
+                        lit: Lit::Str(_), ..
+                    }) = e
+                    {
+                        Some(())
+                    } else {
+                        None
+                    }
+                })
+                .is_some()
+        })
+        .expect("tracing macro needs a string literal message");
+
+    let (front, back) = segments.split_at(split_at);
+    let fmt_seg = &back[0]; // the literal
+    let rest = &back[1..]; // possible extra exprs
+
+    // pull out the literal text & span
+    let lit_expr: Expr = parse2(fmt_seg.clone()).unwrap();
+    let lit_str: LitStr = match lit_expr {
+        Expr::Lit(syn::ExprLit {
+            lit: Lit::Str(s), ..
+        }) => s,
+        _ => unreachable!(),
+    };
+
+    let (fmt, expr) = formati_args(&lit_str);
+    let fmt_str = LitStr::new(&fmt, lit_str.span());
+
+    // extra args (after the literal): named first, then positional
+    let mut named = Vec::<TokenStream2>::new();
+    let mut positional = Vec::<TokenStream2>::new();
+    for seg in rest {
+        let expr: Expr = parse2(seg.clone()).expect("invalid expression after template");
+        match expr {
+            Expr::Assign(ExprAssign { .. }) => named.push(expr.to_token_stream()),
+            _ => positional.push(expr.to_token_stream()),
+        }
+    }
+
+    // emit the real tracing macro call
+    let tracing_macro = syn::Ident::new(kind, proc_macro2::Span::call_site());
+    let front: Vec<&TokenStream2> = front.iter().collect();
+
+    quote! {
+        ::tracing::#tracing_macro!(
+            #(#front ,)*
+            #fmt_str
+            #(, #named)*
+            #(, #expr)*
+            #(, #positional)*
+        )
+    }
+    .into()
+}

--- a/tests/test_anyhow.rs
+++ b/tests/test_anyhow.rs
@@ -1,0 +1,112 @@
+#[cfg(feature = "anyhow")]
+mod test_anyhow {
+    use formati::{anyhow, bail};
+
+    #[test]
+    fn test_anyhow_basic() {
+        let user_id = 42;
+        let username = "test_user";
+
+        let err = anyhow!("Failed to process user {username} with ID {user_id}");
+        assert_eq!(
+            err.to_string(),
+            "Failed to process user test_user with ID 42"
+        );
+    }
+
+    #[test]
+    fn test_anyhow_dotted_access() {
+        struct User {
+            id: u32,
+            name: String,
+        }
+
+        let user = User {
+            id: 42,
+            name: String::from("Alice"),
+        };
+
+        let err = anyhow!("Failed to process user {user.name} with ID {user.id}");
+        assert_eq!(err.to_string(), "Failed to process user Alice with ID 42");
+    }
+
+    #[test]
+    fn test_anyhow_repeated_expression() {
+        struct User {
+            id: u32,
+            name: String,
+        }
+
+        let user = User {
+            id: 42,
+            name: String::from("Alice"),
+        };
+
+        let err = anyhow!(
+            "User {user.name} with ID {user.id} not found. Cannot process user {user.name}."
+        );
+        assert_eq!(
+            err.to_string(),
+            "User Alice with ID 42 not found. Cannot process user Alice."
+        );
+    }
+
+    #[test]
+    fn test_bail_function() {
+        fn process_user(user_id: u32, admin: bool) -> anyhow::Result<()> {
+            if !admin {
+                bail!("User {user_id} is not an admin");
+            }
+            Ok(())
+        }
+
+        // This should return an error
+        let result = process_user(42, false);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "User 42 is not an admin");
+
+        // This should succeed
+        let result = process_user(42, true);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_bail_dotted_access() {
+        struct User {
+            id: u32,
+            name: String,
+            active: bool,
+        }
+
+        fn validate_user(user: &User) -> anyhow::Result<()> {
+            if !user.active {
+                bail!("User {user.name} (ID: {user.id}) is not active");
+            }
+            Ok(())
+        }
+
+        let inactive_user = User {
+            id: 42,
+            name: String::from("Alice"),
+            active: false,
+        };
+
+        let active_user = User {
+            id: 43,
+            name: String::from("Bob"),
+            active: true,
+        };
+
+        // This should return an error
+        let result = validate_user(&inactive_user);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "User Alice (ID: 42) is not active"
+        );
+
+        // This should succeed
+        let result = validate_user(&active_user);
+        assert!(result.is_ok());
+    }
+}

--- a/tests/test_formati.rs
+++ b/tests/test_formati.rs
@@ -1,257 +1,106 @@
-use formati::*;
-use std::f32::consts;
-use std::io::Write;
-use std::sync::{Arc, Mutex};
-use tracing::Level;
-use tracing_subscriber::{
-    fmt::{format::FmtSpan, MakeWriter},
-    FmtSubscriber,
-};
+mod test_formati {
+    use formati::format;
+    use std::f32::consts;
 
-// Create a custom writer to capture log output
-#[derive(Clone, Default)]
-struct TestWriter {
-    captured: Arc<Mutex<Vec<u8>>>,
-}
-
-impl TestWriter {
-    fn new() -> Self {
-        Self {
-            captured: Arc::new(Mutex::new(Vec::new())),
-        }
+    #[test]
+    fn test_formati_basic() {
+        let answer = 42;
+        let result = format!("The answer is {answer}");
+        assert_eq!(result, "The answer is 42");
     }
 
-    fn captured_output(&self) -> String {
-        let captured = self.captured.lock().unwrap();
-        String::from_utf8(captured.clone()).unwrap()
-    }
-}
-
-impl<'a> MakeWriter<'a> for TestWriter {
-    type Writer = GuardedWriter<'a>;
-
-    fn make_writer(&'a self) -> Self::Writer {
-        GuardedWriter {
-            guard: self.captured.lock().unwrap(),
-        }
-    }
-}
-
-struct GuardedWriter<'a> {
-    guard: std::sync::MutexGuard<'a, Vec<u8>>,
-}
-
-impl Write for GuardedWriter<'_> {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.guard.extend_from_slice(buf);
-        Ok(buf.len())
+    #[test]
+    fn test_formati_dotted_access() {
+        let user = (String::from("Alice"), 30);
+        let result = format!("Name: {user.0}, Age: {user.1}");
+        assert_eq!(result, "Name: Alice, Age: 30");
     }
 
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
-
-// Helper to set up tracing for tests
-fn setup_tracing() -> (TestWriter, tracing::subscriber::DefaultGuard) {
-    let writer = TestWriter::new();
-    let subscriber = FmtSubscriber::builder()
-        .with_max_level(Level::TRACE)
-        .with_writer(writer.clone())
-        .with_span_events(FmtSpan::NONE)
-        .finish();
-
-    let guard = tracing::subscriber::set_default(subscriber);
-    (writer, guard)
-}
-
-#[test]
-fn test_formati_basic() {
-    let answer = 42;
-    let result = formati!("The answer is {answer}");
-    assert_eq!(result, "The answer is 42");
-}
-
-#[test]
-fn test_formati_dotted_access() {
-    let user = (String::from("Alice"), 30);
-    let result = formati!("Name: {user.0}, Age: {user.1}");
-    assert_eq!(result, "Name: Alice, Age: 30");
-}
-
-#[test]
-fn test_formati_formatting_specs() {
-    let value = consts::PI;
-    let result = formati!("Pi: {value:.2}");
-    assert_eq!(result, "Pi: 3.14");
-}
-
-#[test]
-fn test_formati_repeated_expression() {
-    let person = (String::from("Bob"), 25);
-    let result = formati!("Name: {person.0}, Info: {person.0} is {person.1} years old");
-    assert_eq!(result, "Name: Bob, Info: Bob is 25 years old");
-}
-
-#[test]
-fn test_formati_nested_structures() {
-    let data = ((1, 2), (3, 4));
-    let result = formati!("Values: {data.0.0}, {data.0.1}, {data.1.0}, {data.1.1}");
-    assert_eq!(result, "Values: 1, 2, 3, 4");
-}
-
-#[test]
-fn test_formati_with_named_args() {
-    let x = 10;
-    let y = 20;
-    let result = formati!("{x} + {y} = {sum}", sum = x + y);
-    assert_eq!(result, "10 + 20 = 30");
-}
-
-#[test]
-fn test_formati_escaped_braces() {
-    let result = formati!("{{escaped}} but {not}", not = "interpolated");
-    assert_eq!(result, "{escaped} but interpolated");
-}
-
-// Full functional test of tracing macros
-#[test]
-fn test_tracing_macros() {
-    let (writer, _guard) = setup_tracing();
-
-    let user_id = 42;
-    let username = "test_user";
-
-    // Test info! macro with simple values
-    info!("User logged in: {username} with id {user_id}");
-    let output = writer.captured_output();
-    assert!(output.contains("User logged in: test_user with id 42"));
-
-    // Reset capture
-    let (writer, _guard) = setup_tracing();
-
-    // Test debug! macro with dotted notation
-    let user = (username, user_id);
-    debug!("Debug info: username={user.0}, id={user.1}");
-    let output = writer.captured_output();
-    assert!(output.contains("Debug info: username=test_user, id=42"));
-
-    // Reset capture
-    let (writer, _guard) = setup_tracing();
-
-    // Test error! macro with named arguments
-    error!("Error processing user {name}", name = username);
-    let output = writer.captured_output();
-    assert!(output.contains("Error processing user test_user"));
-
-    // Reset capture
-    let (writer, _guard) = setup_tracing();
-
-    // Test trace! with target and repeated expressions
-    trace!(target: "auth_service", "User {user.0} logged in with ID {user.1}, welcome {user.0}!");
-    let output = writer.captured_output();
-    assert!(output.contains("User test_user logged in with ID 42, welcome test_user!"));
-
-    // Reset capture
-    let (writer, _guard) = setup_tracing();
-
-    // Test with complex objects and attributes
-    let account = (("premium", true), 365);
-    info!(
-        account.type = account.0.0,
-        active = account.0.1,
-        "Account details: type={account.0.0}, active={account.0.1}, days={account.1}"
-    );
-    let output = writer.captured_output();
-    assert!(output.contains("Account details: type=premium, active=true, days=365"));
-}
-
-// Advanced usage with mixed features
-#[test]
-fn test_complex_integration() {
-    let person = ("Alice", 30, "Engineer");
-    let address = ("123 Main St", "Anytown", "USA");
-
-    let complex = formati!(
-        "Person: {person.0}, Age: {person.1}\n\
-             Job: {person.2}\n\
-             Address: {address.0}, {address.1}, {address.2}\n\
-             Person again: {person.0}",
-    );
-
-    assert_eq!(
-        complex,
-        "Person: Alice, Age: 30\n\
-             Job: Engineer\n\
-             Address: 123 Main St, Anytown, USA\n\
-             Person again: Alice"
-    );
-
-    // Also test with tracing
-    let (writer, _guard) = setup_tracing();
-
-    info!(
-        department = "Engineering",
-        years_of_service = 5,
-        "Complex info: {person.0} is a {person.2} living in {address.1}, {address.2}"
-    );
-
-    let output = writer.captured_output();
-    assert!(output.contains("Complex info: Alice is a Engineer living in Anytown, USA"));
-}
-
-#[test]
-fn test_formati_struct_fields_and_methods() {
-    // Define a realistic struct with fields and methods
-    struct Employee {
-        id: u32,
-        salary: i32,
-        department: String,
+    #[test]
+    fn test_formati_formatting_specs() {
+        let value = consts::PI;
+        let result = format!("Pi: {value:.2}");
+        assert_eq!(result, "Pi: 3.14");
     }
 
-    impl Employee {
-        fn get_title(&self) -> &str {
-            "Software Engineer"
+    #[test]
+    fn test_formati_repeated_expression() {
+        let person = (String::from("Bob"), 25);
+        let result = format!("Name: {person.0}, Info: {person.0} is {person.1} years old");
+        assert_eq!(result, "Name: Bob, Info: Bob is 25 years old");
+    }
+
+    #[test]
+    fn test_formati_nested_structures() {
+        let data = ((1, 2), (3, 4));
+        let result = format!("Values: {data.0.0}, {data.0.1}, {data.1.0}, {data.1.1}");
+        assert_eq!(result, "Values: 1, 2, 3, 4");
+    }
+
+    #[test]
+    fn test_formati_with_named_args() {
+        let x = 10;
+        let y = 20;
+        let result = format!("{x} + {y} = {sum}", sum = x + y);
+        assert_eq!(result, "10 + 20 = 30");
+    }
+
+    #[test]
+    fn test_formati_escaped_braces() {
+        let result = format!("{{escaped}} but {not}", not = "interpolated");
+        assert_eq!(result, "{escaped} but interpolated");
+    }
+
+    #[test]
+    fn test_formati_struct_fields_and_methods() {
+        struct Employee {
+            id: u32,
+            salary: i32,
+            department: String,
         }
 
-        fn format_id(&self) -> String {
-            format!("EMP-{:04}", self.id)
+        impl Employee {
+            fn get_title(&self) -> &str {
+                "Software Engineer"
+            }
+
+            fn format_id(&self) -> String {
+                format!("EMP-{:04}", self.id)
+            }
         }
-    }
 
-    // Create test instance
-    let employee = Employee {
-        id: 157,
-        salary: 85000,
-        department: String::from("Engineering"),
-    };
+        let employee = Employee {
+            id: 157,
+            salary: 85000,
+            department: String::from("Engineering"),
+        };
 
-    // Additional tuple for testing
-    let project_data = (2023, "Project Formati");
+        let project_data = (2023, "Project Formati");
 
-    // Test accessing struct fields, method calls, and repeated expressions
-    let result = formati!(
-        "Employee ID: {employee.id}, Department: {employee.department}\n\
+        // Test accessing struct fields, method calls, and repeated expressions
+        let result = format!(
+            "Employee ID: {employee.id}, Department: {employee.department}\n\
          Salary: ${employee.salary}, Title: {employee.get_title()}\n\
          Formatted ID: {employee.format_id()}, Employee ID again: {employee.id}\n\
-         Project Year: {project_data.0}, Project Name: {project_data.1}"
-    );
+         Project Year: {project_data.0}, Project Name: {project_data.1}",
+        );
 
-    assert_eq!(
-        result,
-        "Employee ID: 157, Department: Engineering\n\
+        assert_eq!(
+            result,
+            "Employee ID: 157, Department: Engineering\n\
          Salary: $85000, Title: Software Engineer\n\
          Formatted ID: EMP-0157, Employee ID again: 157\n\
          Project Year: 2023, Project Name: Project Formati"
-    );
+        );
 
-    // Verify that method calls are handled correctly
-    let method_result = formati!("Employee: {employee.format_id()} - {employee.get_title()}");
-    assert_eq!(method_result, "Employee: EMP-0157 - Software Engineer");
+        // Verify that method calls are handled correctly
+        let method_result = format!("Employee: {employee.format_id()} - {employee.get_title()}");
+        assert_eq!(method_result, "Employee: EMP-0157 - Software Engineer");
 
-    // Test with formatting specifiers
-    let detail_result = formati!(
+        // Test with formatting specifiers
+        let detail_result = format!(
         "ID: {employee.id:04}, Salary: {employee.salary:+}, Department: {employee.department:.5}"
     );
-    assert_eq!(detail_result, "ID: 0157, Salary: +85000, Department: Engin");
+        assert_eq!(detail_result, "ID: 0157, Salary: +85000, Department: Engin");
+    }
 }

--- a/tests/test_log.rs
+++ b/tests/test_log.rs
@@ -1,0 +1,223 @@
+#[cfg(feature = "log")]
+mod test {
+    use log::{LevelFilter, Log, Metadata, Record};
+    use std::sync::{Arc, Mutex, OnceLock};
+
+    use formati::{debug, error, format, info, trace, warn};
+
+    // Global static logger for all tests
+    static LOGGER: OnceLock<TestLogger> = OnceLock::new();
+
+    #[derive(Clone)]
+    struct TestLogger {
+        captured: Arc<Mutex<Vec<String>>>,
+        level: LevelFilter,
+    }
+
+    impl TestLogger {
+        fn new() -> Self {
+            Self {
+                captured: Arc::new(Mutex::new(Vec::new())),
+                level: LevelFilter::Trace,
+            }
+        }
+
+        fn captured_logs(&self) -> Vec<String> {
+            let guard = self.captured.lock().unwrap();
+            guard.clone()
+        }
+
+        fn clear(&self) {
+            let mut guard = self.captured.lock().unwrap();
+            guard.clear();
+        }
+
+        // Get the global instance, initializing if needed
+        fn get_instance() -> &'static TestLogger {
+            LOGGER.get_or_init(|| {
+                let logger = TestLogger::new();
+                // Initialize logger only once
+                let _ = log::set_boxed_logger(Box::new(logger.clone()));
+                log::set_max_level(LevelFilter::Trace);
+                logger
+            })
+        }
+    }
+
+    impl Log for TestLogger {
+        fn enabled(&self, metadata: &Metadata) -> bool {
+            metadata.level() <= self.level
+        }
+
+        fn log(&self, record: &Record) {
+            if self.enabled(record.metadata()) {
+                let message = format!("[{record.target()}] {record.level()}: {record.args()}");
+                let mut guard = self.captured.lock().unwrap();
+                guard.push(message);
+            }
+        }
+
+        fn flush(&self) {}
+    }
+
+    // Instead of setting up a new logger each time, get the global instance
+    fn setup_logger() -> &'static TestLogger {
+        TestLogger::get_instance()
+    }
+
+    // Test log enhanced macros
+    #[test]
+    fn test_log_macros_basic() {
+        let logger = setup_logger();
+        logger.clear(); // Start with a clean state
+
+        let user_id = 42;
+        let username = "test_user";
+
+        info!("User {username} logged in with ID {user_id}");
+        let logs = logger.captured_logs();
+        assert_eq!(logs.len(), 1);
+        assert!(logs[0].contains("User test_user logged in with ID 42"));
+
+        logger.clear();
+
+        error!("Failed to process user {username}");
+        let logs = logger.captured_logs();
+        assert_eq!(logs.len(), 1);
+        assert!(logs[0].contains("Failed to process user test_user"));
+
+        logger.clear();
+
+        warn!("User {username} has suspicious activity");
+        let logs = logger.captured_logs();
+        assert_eq!(logs.len(), 1);
+        assert!(logs[0].contains("User test_user has suspicious activity"));
+
+        logger.clear();
+
+        debug!("Debug: user={username}, id={user_id}");
+        let logs = logger.captured_logs();
+        assert_eq!(logs.len(), 1);
+        assert!(logs[0].contains("Debug: user=test_user, id=42"));
+
+        logger.clear();
+
+        trace!("Trace: user_login(user={username}, id={user_id})");
+        let logs = logger.captured_logs();
+        assert_eq!(logs.len(), 1);
+        assert!(logs[0].contains("Trace: user_login(user=test_user, id=42)"));
+    }
+
+    #[test]
+    fn test_log_macros_dotted_access() {
+        let logger = setup_logger();
+        logger.clear(); // Start with a clean state
+
+        struct User {
+            id: u32,
+            name: String,
+            access_level: String,
+        }
+
+        let user = User {
+            id: 42,
+            name: String::from("Alice"),
+            access_level: String::from("admin"),
+        };
+
+        info!("User {user.name} logged in with ID {user.id}");
+        let logs = logger.captured_logs();
+        assert_eq!(logs.len(), 1);
+        assert!(logs[0].contains("User Alice logged in with ID 42"));
+
+        logger.clear();
+
+        error!("Cannot grant {user.access_level} privileges to user {user.name}");
+        let logs = logger.captured_logs();
+        assert_eq!(logs.len(), 1);
+        assert!(logs[0].contains("Cannot grant admin privileges to user Alice"));
+
+        logger.clear();
+
+        // Test with target specification
+        debug!("User {user.name} authenticated with level {user.access_level}");
+        let logs = logger.captured_logs();
+        assert_eq!(logs.len(), 1);
+        assert!(logs[0].contains("User Alice authenticated with level admin"));
+    }
+
+    #[test]
+    fn test_log_macros_nested_access() {
+        let logger = setup_logger();
+        logger.clear(); // Start with a clean state
+
+        let data = ((1, 2), (3, "test"));
+
+        info!("Values: {data.0.0}, {data.0.1}, {data.1.0}, {data.1.1}");
+        let logs = logger.captured_logs();
+        assert_eq!(logs.len(), 1);
+        assert!(logs[0].contains("Values: 1, 2, 3, test"));
+
+        logger.clear();
+
+        // Test with method calls
+        struct Database {
+            name: String,
+            size: usize,
+        }
+
+        impl Database {
+            fn connection_string(&self) -> String {
+                format!("db://{}", self.name)
+            }
+
+            fn format_size(&self) -> String {
+                format!("{} MB", self.size)
+            }
+        }
+
+        let db = Database {
+            name: String::from("users_db"),
+            size: 1024,
+        };
+
+        info!("Connected to {db.connection_string()} (size: {db.format_size()})");
+        let logs = logger.captured_logs();
+        assert_eq!(logs.len(), 1);
+        assert!(logs[0].contains("Connected to db://users_db (size: 1024 MB)"));
+    }
+
+    #[test]
+    fn test_log_macros_repeated_expression() {
+        let logger = setup_logger();
+        logger.clear(); // Start with a clean state
+
+        struct User {
+            id: u32,
+            name: String,
+        }
+
+        let user = User {
+            id: 42,
+            name: String::from("Alice"),
+        };
+
+        // The user.name expression should only be evaluated once
+        info!("User {user.name} logged in. Welcome back, {user.name}!");
+        let logs = logger.captured_logs();
+        assert_eq!(logs.len(), 1);
+        assert!(logs[0].contains("User Alice logged in. Welcome back, Alice!"));
+
+        logger.clear();
+
+        // Complex case with multiple repeated expressions
+        debug!(
+            "User ID: {user.id}, Name: {user.name}\n\
+             Processing request for {user.name} (ID: {user.id})"
+        );
+        let logs = logger.captured_logs();
+        assert_eq!(logs.len(), 1);
+        assert!(logs[0].contains("User ID: 42, Name: Alice"));
+        assert!(logs[0].contains("Processing request for Alice (ID: 42)"));
+    }
+}

--- a/tests/test_stdio.rs
+++ b/tests/test_stdio.rs
@@ -1,0 +1,108 @@
+#![cfg(feature = "stdio")]
+mod test_stdio {
+    use formati::{print, println};
+    use std::fs::{read_to_string, remove_file};
+    use std::io::{self, Write};
+    use std::path::PathBuf;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Mutex,
+    };
+    use stdio_override::StdoutOverride;
+
+    static CAPTURE_LOCK: Mutex<()> = Mutex::new(());
+
+    // Generate a unique tmp‑file path for every capture.
+    fn temp_path() -> PathBuf {
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::SeqCst);
+        let mut p = std::env::temp_dir();
+        p.push(format!("formati_stdio_test_{id}.txt"));
+        p
+    }
+
+    /// Redirect stdout to a temp file while running `f` **inside a new
+    /// thread** (so we escape the test‑harness’s per‑thread capture).
+    fn with_captured_stdout<F>(f: F) -> String
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        let _lock = CAPTURE_LOCK.lock().unwrap();
+
+        let path = temp_path();
+        io::stdout().flush().ok();
+        let guard = StdoutOverride::from_file(&path).expect("override failed");
+
+        std::thread::spawn(move || {
+            f();
+            io::stdout().flush().ok();
+        })
+        .join()
+        .expect("thread panicked in with_captured_stdout");
+
+        // drop the guard *after* the prints are done so everything is flushed
+        drop(guard);
+
+        let contents = read_to_string(&path).expect("read capture file");
+        let _ = remove_file(&path);
+        contents
+    }
+
+    // Tests
+
+    #[test]
+    fn test_print_basic() {
+        let (name, age) = ("Alice", 30);
+        let out = with_captured_stdout(move || {
+            print!("Name: {name}, Age: {age}");
+        });
+        assert_eq!(out, "Name: Alice, Age: 30");
+    }
+
+    #[test]
+    fn test_println_basic() {
+        let (name, age) = ("Bob", 25);
+        let out = with_captured_stdout(move || {
+            println!("Name: {name}, Age: {age}");
+        });
+        assert_eq!(out, "Name: Bob, Age: 25\n");
+    }
+
+    #[test]
+    fn test_stdio_dotted_access() {
+        struct User {
+            id: u32,
+            name: String,
+        }
+        impl User {
+            fn format_id(&self) -> String {
+                format!("USER-{:<04}", self.id)
+            }
+        }
+
+        let user = User {
+            id: 42,
+            name: "Carol".into(),
+        };
+
+        let out = with_captured_stdout(move || {
+            println!("User: {user.name} (ID: {user.id})");
+            print!("Formatted ID: {user.format_id()}");
+        });
+
+        assert_eq!(out, "User: Carol (ID: 42)\nFormatted ID: USER-0042");
+    }
+
+    #[test]
+    fn test_stdio_repeated_expressions() {
+        let point = (3.1, 2.71);
+        let out = with_captured_stdout(move || {
+            println!("Point: ({point.0}, {point.1})");
+            println!(
+                "Normalized: ({point.0}/{point.0+point.1:.2}, {point.1}/{point.0+point.1:.2})"
+            );
+        });
+        assert!(out.contains("Point: (3.1, 2.71)"));
+        assert!(out.contains("Normalized: (3.1/5.81, 2.71/5.81)"));
+    }
+}

--- a/tests/test_tracing.rs
+++ b/tests/test_tracing.rs
@@ -1,0 +1,135 @@
+#[cfg(feature = "tracing")]
+mod test_tracing {
+    use formati::{debug, error, info, trace, warn};
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+    use tracing::Level;
+    use tracing_subscriber::{
+        fmt::{format::FmtSpan, MakeWriter},
+        FmtSubscriber,
+    };
+
+    // Create a custom writer to capture log output
+    #[derive(Clone, Default)]
+    struct TestWriter {
+        captured: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl TestWriter {
+        fn new() -> Self {
+            Self {
+                captured: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn captured_output(&self) -> String {
+            let captured = self.captured.lock().unwrap();
+            String::from_utf8(captured.clone()).unwrap()
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for TestWriter {
+        type Writer = GuardedWriter<'a>;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            GuardedWriter {
+                guard: self.captured.lock().unwrap(),
+            }
+        }
+    }
+
+    struct GuardedWriter<'a> {
+        guard: std::sync::MutexGuard<'a, Vec<u8>>,
+    }
+
+    impl Write for GuardedWriter<'_> {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.guard.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    // Helper to set up tracing for tests
+    fn setup_tracing() -> (TestWriter, tracing::subscriber::DefaultGuard) {
+        let writer = TestWriter::new();
+        let subscriber = FmtSubscriber::builder()
+            .with_max_level(Level::TRACE)
+            .with_writer(writer.clone())
+            .with_span_events(FmtSpan::NONE)
+            .finish();
+
+        let guard = tracing::subscriber::set_default(subscriber);
+        (writer, guard)
+    }
+
+    // Tests
+
+    // Full functional test of tracing macros
+    #[test]
+    fn test_tracing_events() {
+        let (writer, _guard) = setup_tracing();
+
+        let user_id = 42;
+        let username = "test_user";
+
+        // Test info! macro with simple values
+        info!("User logged in: {username} with id {user_id}");
+        let output = writer.captured_output();
+        assert!(output.contains("User logged in: test_user with id 42"));
+
+        let (writer, _guard) = setup_tracing();
+
+        // Test debug! macro with dotted notation
+        let user = (username, user_id);
+        debug!("Debug info: username={user.0}, id={user.1}");
+        let output = writer.captured_output();
+        assert!(output.contains("Debug info: username=test_user, id=42"));
+
+        let (writer, _guard) = setup_tracing();
+
+        // Test error! macro with named arguments
+        error!("Error processing user {name}", name = username);
+        let output = writer.captured_output();
+        assert!(output.contains("Error processing user test_user"));
+
+        let (writer, _guard) = setup_tracing();
+
+        // Test trace! with target and repeated expressions
+        trace!(target: "auth_service", "User {user.0} logged in with ID {user.1}, welcome {user.0}!");
+        let output = writer.captured_output();
+        assert!(output.contains("User test_user logged in with ID 42, welcome test_user!"));
+
+        let (writer, _guard) = setup_tracing();
+
+        // Test with complex objects and attributes
+        let account = (("premium", true), 365);
+        info!(
+            account.type = account.0.0,
+            active = account.0.1,
+            "Account details: type={account.0.0}, active={account.0.1}, days={account.1}"
+        );
+        let output = writer.captured_output();
+        assert!(output.contains("Account details: type=premium, active=true, days=365"));
+    }
+
+    #[test]
+    fn test_event_fields() {
+        let person = ("Alice", 30, "Engineer");
+        let address = ("123 Main St", "Anytown", "USA");
+
+        let (writer, _guard) = setup_tracing();
+
+        info!(
+            department = "Engineering",
+            years_of_service = 5,
+            "Complex info: {person.0} is a {person.2} living in {address.1}, {address.2}"
+        );
+
+        let output = writer.captured_output();
+        assert!(output.contains("Complex info: Alice is a Engineer living in Anytown, USA"));
+    }
+}


### PR DESCRIPTION
Additionally:
- improved test coverage
- fixed trailing commas failing to parse
- closes #1